### PR TITLE
macos "OS Error: Operation not permitted" fix

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,6 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+  <key>com.apple.security.files.user-selected.read-only</key>
 </dict>
 </plist>


### PR DESCRIPTION
entitlement is essential to control what resources the app can access.
https://docs.flutter.dev/platform-integration/macos/building#setting-up-entitlements

add the following to `./macos/Runner/DebugProfile.entitlements` fix the bug "OS Error: Operation not permitted"

```	<key>com.apple.security.files.user-selected.read-only</key>
```
