### PR TITLE
Yyx/117 wordcloud restructure

### DIFF
--- a/lib/features/model/forest/tab.dart
+++ b/lib/features/model/forest/tab.dart
@@ -29,15 +29,8 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'package:rattle/constants/app.dart';
-import 'package:rattle/constants/colors.dart';
 import 'package:rattle/features/model/forest/config.dart';
 import 'package:rattle/features/model/forest/panel.dart';
-import 'package:rattle/provider/stdout.dart';
-import 'package:rattle/r/extract_forest.dart';
-import 'package:rattle/utils/add_build_button.dart';
 
 /// The FOREST tab supports building decision tree models.
 

--- a/lib/features/model/tab.dart
+++ b/lib/features/model/tab.dart
@@ -60,7 +60,7 @@ final List<Map<String, dynamic>> modelTabs = [
   },
   {
     'title': 'Forest',
-    'widget': ForestTab(),
+    'widget': const ForestTab(),
   },
   {
     'title': 'Boost',

--- a/lib/features/model/tree/tab.dart
+++ b/lib/features/model/tree/tab.dart
@@ -29,15 +29,8 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'package:rattle/constants/app.dart';
-import 'package:rattle/constants/colors.dart';
 import 'package:rattle/features/model/tree/config.dart';
 import 'package:rattle/features/model/tree/panel.dart';
-import 'package:rattle/provider/stdout.dart';
-import 'package:rattle/r/extract_tree.dart';
-import 'package:rattle/utils/add_build_button.dart';
 
 /// The TREE tab supports building decision tree models.
 
@@ -71,4 +64,3 @@ class TreeTab extends StatelessWidget {
     );
   }
 }
-

--- a/lib/features/model/wordcloud/panel.dart
+++ b/lib/features/model/wordcloud/panel.dart
@@ -1,0 +1,160 @@
+/// Panel for word cloud.
+//
+// Time-stamp: <Monday 2024-06-10 10:34:53 +1000 Graham Williams>
+//
+/// Copyright (C) 2024, Togaware Pty Ltd
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Yixiang Yin, Graham Williams
+
+library;
+
+// Group imports by dart, flutter, packages, local. Then alphabetically.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:rattle/constants/colors.dart';
+import 'package:rattle/constants/wordcloud.dart';
+import 'package:rattle/features/model/wordcloud/config.dart';
+import 'package:rattle/provider/wordcloud/build.dart';
+import 'package:rattle/widgets/markdown_file.dart';
+
+class WordCloudPanel extends ConsumerStatefulWidget {
+  const WordCloudPanel({super.key});
+  @override
+  ConsumerState<WordCloudPanel> createState() => _WordCloudPanelState();
+}
+
+bool buildButtonPressed(String buildTime) {
+  return buildTime.isNotEmpty;
+}
+
+class _WordCloudPanelState extends ConsumerState<WordCloudPanel> {
+  @override
+  Widget build(BuildContext context) {
+    // Build the word cloud widget to be displayed in the tab, consisting of the
+    // top configuration and the main panel showing the generated image. Before
+    // the build we display a introdcurory text to the functionality.
+
+    // Reload the wordcloud image.
+
+    imageCache.clear();
+    imageCache.clearLiveImages();
+    String lastBuildTime = ref.watch(wordCloudBuildProvider);
+    debugPrint('received rebuild on $lastBuildTime');
+    var wordCloudFile = File(wordCloudImagePath);
+    bool fileExists = wordCloudFile.existsSync();
+
+    // Identify a widget for the display of the word cloud image file. Default
+    // to a BUG display! The traditional 'This should not happen'.
+
+    Widget imageDisplay = const Text('This should not happen.');
+    // file exists | build not empty
+    // 1 | 1 -> show the png
+    // 1 | 0 -> show not built
+    // 0 | 0 -> show not built
+    // 0 | 1 -> show loading
+    if (buildButtonPressed(lastBuildTime)) {
+      if (fileExists) {
+        // build button pressed and png file exists
+        debugPrint('Model built. Now Sleeping as needed to await file.');
+
+        // Reload the image:
+        // https://nambiarakhilraj01.medium.com/
+        // what-to-do-if-fileimage-imagepath-does-not-update-on-build-in-flutter-622ad5ac8bca
+
+        var bytes = wordCloudFile.readAsBytesSync();
+
+        // TODO 20240601 gjw WITHOUT A DELAY HERE WE SEE AN EXCEPTION ON LINUX
+        //
+        // _Exception was thrown resolving an image codec:
+        // Exception: Invalid image data
+        //
+        // ON PRINTING bytes WE SEE AN EMPYT LIST OF BYTES UNTIL THE FILE IS
+        // LOADED SUCCESSFULLY.
+        //
+        // WITH THE SLEEP WE AVOID IT. SO WE SLEEP LONG ENOUGH FOR THE FILE THE BE
+        // SUCCESSFULLY LOADED (BECUSE IT IS NOT YET WRITTEN?) SO WE NEED TO WAIT
+        // UNTIL THE FILE IS READY.
+        //
+        // THERE MIGHT BE A BETTER WAY TO DO THIS - WAIT SYNCHRONLOUSLY?
+
+        while (bytes.lengthInBytes == 0) {
+          sleep(const Duration(seconds: 1));
+          bytes = wordCloudFile.readAsBytesSync();
+        }
+
+        Image image = Image.memory(bytes);
+
+        // Build the widget to display the image. Make it a row, centering the
+        // image horizontally, and so ensuring the scrollbar is all the way to the
+        // right.
+
+        imageDisplay = Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            image,
+          ],
+        );
+      } else {
+        // build button pressed but png not exists
+        imageDisplay = const Column(
+          children: [
+            SizedBox(height: 50),
+            Text('Loading'),
+          ],
+        );
+      }
+    } else {
+      // build button not pressed
+      // If there is no image built then return a widget that displays the word
+      // cloud introductory message, but with the config bar also displayed.
+      debugPrint('No model has been built.');
+
+      return
+          // TODO 20240605 gjw NOT QUIT THE RIGHT SOLUTION YET. IF I SET MAX
+          // WORDS TO 10 WHILE THE MSG IS DISPLAYED THEN BUILD, IT GET THE
+          // PARAMETER BUT AFTER THE BUILD/REFRESH THE 10 IS LOST FROM THE
+          // CONFIG BAR SINCE IT IS REBUILT. HOW TO FIX THAT AND RETAIN THE
+          // MESSAGE WITHTHE CONFIG BAR.
+          Expanded(
+        child: Center(
+          child: sunkenMarkdownFileBuilder(wordCloudMsgFile),
+        ),
+      );
+    }
+
+    return wordCloudPanel(imageDisplay);
+  }
+}
+
+Widget wordCloudPanel(Widget wordCloudBody) {
+  return Expanded(
+    child: Container(
+      decoration: sunkenBoxDecoration,
+      child: SingleChildScrollView(
+        child: wordCloudBody,
+      ),
+    ),
+  );
+}

--- a/lib/features/model/wordcloud/panel.dart
+++ b/lib/features/model/wordcloud/panel.dart
@@ -132,11 +132,7 @@ class _WordCloudPanelState extends ConsumerState<WordCloudPanel> {
       debugPrint('No model has been built.');
 
       return
-          // TODO 20240605 gjw NOT QUIT THE RIGHT SOLUTION YET. IF I SET MAX
-          // WORDS TO 10 WHILE THE MSG IS DISPLAYED THEN BUILD, IT GET THE
-          // PARAMETER BUT AFTER THE BUILD/REFRESH THE 10 IS LOST FROM THE
-          // CONFIG BAR SINCE IT IS REBUILT. HOW TO FIX THAT AND RETAIN THE
-          // MESSAGE WITHTHE CONFIG BAR.
+
           Expanded(
         child: Center(
           child: sunkenMarkdownFileBuilder(wordCloudMsgFile),

--- a/lib/features/model/wordcloud/panel.dart
+++ b/lib/features/model/wordcloud/panel.dart
@@ -35,7 +35,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:rattle/constants/colors.dart';
 import 'package:rattle/constants/wordcloud.dart';
-import 'package:rattle/features/model/wordcloud/config.dart';
 import 'package:rattle/provider/wordcloud/build.dart';
 import 'package:rattle/widgets/markdown_file.dart';
 
@@ -131,9 +130,7 @@ class _WordCloudPanelState extends ConsumerState<WordCloudPanel> {
       // cloud introductory message, but with the config bar also displayed.
       debugPrint('No model has been built.');
 
-      return
-
-          Expanded(
+      return Expanded(
         child: Center(
           child: sunkenMarkdownFileBuilder(wordCloudMsgFile),
         ),

--- a/lib/features/model/wordcloud/tab.dart
+++ b/lib/features/model/wordcloud/tab.dart
@@ -27,18 +27,10 @@ library;
 
 // Group imports by dart, flutter, packages, local. Then alphabetically.
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'package:rattle/constants/colors.dart';
-import 'package:rattle/constants/wordcloud.dart';
 import 'package:rattle/features/model/wordcloud/config.dart';
 import 'package:rattle/features/model/wordcloud/panel.dart';
-import 'package:rattle/provider/wordcloud/build.dart';
-import 'package:rattle/widgets/markdown_file.dart';
 
 class WordCloudTab extends StatelessWidget {
   const WordCloudTab({super.key});

--- a/lib/features/model/wordcloud/tab.dart
+++ b/lib/features/model/wordcloud/tab.dart
@@ -42,7 +42,7 @@ import 'package:rattle/widgets/markdown_file.dart';
 
 class WordCloudTab extends StatelessWidget {
   const WordCloudTab({super.key});
-    @override
+  @override
   Widget build(BuildContext context) {
     // A per the RattleNG pattern, a Tab consists of a Config bar and the
     // results Panel.
@@ -50,6 +50,11 @@ class WordCloudTab extends StatelessWidget {
     return const Scaffold(
       body: Column(
         children: [
+          // TODO 20240605 gjw NOT QUIT THE RIGHT SOLUTION YET. IF I SET MAX
+          // WORDS TO 10 WHILE THE MSG IS DISPLAYED THEN BUILD, IT GET THE
+          // PARAMETER BUT AFTER THE BUILD/REFRESH THE 10 IS LOST FROM THE
+          // CONFIG BAR SINCE IT IS REBUILT. HOW TO FIX THAT AND RETAIN THE
+          // MESSAGE WITHTHE CONFIG BAR.
           WordCloudConfig(),
 
           // Add a little space below the underlined input widget so the
@@ -58,6 +63,12 @@ class WordCloudTab extends StatelessWidget {
           // the spacer here as part of the tab.
 
           SizedBox(height: 10),
+          // TODO 20240605 gjw THIS FUNCTIONALITY TO MIGRATE TO THE APP SAVE
+          // BUTTON TOP RIGHT. KEEP HERE AS A COMMENT UNTIL IMPLEMENTED.
+          //
+          // WordCloudSaveButton(
+          //  wordCloudImagePath: wordCloudImagePath,
+          // ),
 
           // A text view that takes up the remaining space and displays the
           // Rattle welcome and getting started message. This will be

--- a/lib/features/model/wordcloud/tab.dart
+++ b/lib/features/model/wordcloud/tab.dart
@@ -1,4 +1,4 @@
-/// Panel for word cloud.
+/// Wordcloud Tab
 //
 // Time-stamp: <Monday 2024-06-10 10:34:53 +1000 Graham Williams>
 //
@@ -36,144 +36,36 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rattle/constants/colors.dart';
 import 'package:rattle/constants/wordcloud.dart';
 import 'package:rattle/features/model/wordcloud/config.dart';
+import 'package:rattle/features/model/wordcloud/panel.dart';
 import 'package:rattle/provider/wordcloud/build.dart';
 import 'package:rattle/widgets/markdown_file.dart';
 
-class WordCloudTab extends ConsumerStatefulWidget {
+class WordCloudTab extends StatelessWidget {
   const WordCloudTab({super.key});
-  @override
-  ConsumerState<WordCloudTab> createState() => _WordCloudTabState();
-}
-
-bool buildButtonPressed(String buildTime) {
-  return buildTime.isNotEmpty;
-}
-
-class _WordCloudTabState extends ConsumerState<WordCloudTab> {
-  @override
+    @override
   Widget build(BuildContext context) {
-    // Build the word cloud widget to be displayed in the tab, consisting of the
-    // top configuration and the main panel showing the generated image. Before
-    // the build we display a introdcurory text to the functionality.
+    // A per the RattleNG pattern, a Tab consists of a Config bar and the
+    // results Panel.
 
-    // Reload the wordcloud image.
-
-    imageCache.clear();
-    imageCache.clearLiveImages();
-    String lastBuildTime = ref.watch(wordCloudBuildProvider);
-    debugPrint('received rebuild on $lastBuildTime');
-    var wordCloudFile = File(wordCloudImagePath);
-    bool fileExists = wordCloudFile.existsSync();
-
-    // Identify a widget for the display of the word cloud image file. Default
-    // to a BUG display! The traditional 'This should not happen'.
-
-    Widget imageDisplay = const Text('This should not happen.');
-    // file exists | build not empty
-    // 1 | 1 -> show the png
-    // 1 | 0 -> show not built
-    // 0 | 0 -> show not built
-    // 0 | 1 -> show loading
-    if (buildButtonPressed(lastBuildTime)) {
-      if (fileExists) {
-        // build button pressed and png file exists
-        debugPrint('Model built. Now Sleeping as needed to await file.');
-
-        // Reload the image:
-        // https://nambiarakhilraj01.medium.com/
-        // what-to-do-if-fileimage-imagepath-does-not-update-on-build-in-flutter-622ad5ac8bca
-
-        var bytes = wordCloudFile.readAsBytesSync();
-
-        // TODO 20240601 gjw WITHOUT A DELAY HERE WE SEE AN EXCEPTION ON LINUX
-        //
-        // _Exception was thrown resolving an image codec:
-        // Exception: Invalid image data
-        //
-        // ON PRINTING bytes WE SEE AN EMPYT LIST OF BYTES UNTIL THE FILE IS
-        // LOADED SUCCESSFULLY.
-        //
-        // WITH THE SLEEP WE AVOID IT. SO WE SLEEP LONG ENOUGH FOR THE FILE THE BE
-        // SUCCESSFULLY LOADED (BECUSE IT IS NOT YET WRITTEN?) SO WE NEED TO WAIT
-        // UNTIL THE FILE IS READY.
-        //
-        // THERE MIGHT BE A BETTER WAY TO DO THIS - WAIT SYNCHRONLOUSLY?
-
-        while (bytes.lengthInBytes == 0) {
-          sleep(const Duration(seconds: 1));
-          bytes = wordCloudFile.readAsBytesSync();
-        }
-
-        Image image = Image.memory(bytes);
-
-        // Build the widget to display the image. Make it a row, centering the
-        // image horizontally, and so ensuring the scrollbar is all the way to the
-        // right.
-
-        imageDisplay = Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            image,
-          ],
-        );
-      } else {
-        // build button pressed but png not exists
-        imageDisplay = const Column(
-          children: [
-            SizedBox(height: 50),
-            Text('Loading'),
-          ],
-        );
-      }
-    } else {
-      // build button not pressed
-      // If there is no image built then return a widget that displays the word
-      // cloud introductory message, but with the config bar also displayed.
-      debugPrint('No model has been built.');
-
-      return Column(
+    return const Scaffold(
+      body: Column(
         children: [
-          // TODO 20240605 gjw NOT QUIT THE RIGHT SOLUTION YET. IF I SET MAX
-          // WORDS TO 10 WHILE THE MSG IS DISPLAYED THEN BUILD, IT GET THE
-          // PARAMETER BUT AFTER THE BUILD/REFRESH THE 10 IS LOST FROM THE
-          // CONFIG BAR SINCE IT IS REBUILT. HOW TO FIX THAT AND RETAIN THE
-          // MESSAGE WITHTHE CONFIG BAR.
-          const WordCloudConfig(),
-          Expanded(
-            child: Center(
-              child: sunkenMarkdownFileBuilder(wordCloudMsgFile),
-            ),
-          ),
+          WordCloudConfig(),
+
+          // Add a little space below the underlined input widget so the
+          // underline is not lost. Thouoght to include this in config but then
+          // I would need an extra Column widget(). Seems okay logically to add
+          // the spacer here as part of the tab.
+
+          SizedBox(height: 10),
+
+          // A text view that takes up the remaining space and displays the
+          // Rattle welcome and getting started message. This will be
+          // overwritten once a dataset is loaded.
+
+          WordCloudPanel(),
         ],
-      );
-    }
-
-    return wordCloudPanel(imageDisplay);
-  }
-}
-
-Widget wordCloudPanel(Widget wordCloudBody) {
-  return Column(
-    children: [
-      const WordCloudConfig(),
-
-      // TODO 20240605 gjw THIS FUNCTIONALITY TO MIGRATE TO THE APP SAVE
-      // BUTTON TOP RIGHT. KEEP HERE AS A COMMENT UNTIL IMPLEMENTED.
-      //
-      // WordCloudSaveButton(
-      //  wordCloudImagePath: wordCloudImagePath,
-      // ),
-
-      const SizedBox(height: 10),
-
-      Expanded(
-        child: Container(
-          decoration: sunkenBoxDecoration,
-          child: SingleChildScrollView(
-            child: wordCloudBody,
-          ),
-        ),
       ),
-    ],
-  );
+    );
+  }
 }

--- a/lib/provider/dataset_loaded.dart
+++ b/lib/provider/dataset_loaded.dart
@@ -1,4 +1,32 @@
-// capture whether the dataset has been loaded
+/// capture whether the dataset has been loaded
+//
+// Time-stamp: <Thursday 2024-06-06 05:58:50 +1000 Graham Williams>
+//
+/// Copyright (C) 2024, Togaware Pty Ltd
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Yixiang Yin
+
+library;
+
+// Group imports by dart, flutter, packages, local. Then alphabetically.
+
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/provider/dataset_loaded.dart
+++ b/lib/provider/dataset_loaded.dart
@@ -27,7 +27,6 @@ library;
 
 // Group imports by dart, flutter, packages, local. Then alphabetically.
 
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final datasetLoaded = StateProvider<bool>((ref) => false);

--- a/lib/utils/add_build_button.dart
+++ b/lib/utils/add_build_button.dart
@@ -1,4 +1,32 @@
-// add the build button in the tab
+/// add the build button in the tab
+//
+// Time-stamp: <Thursday 2024-06-06 05:58:50 +1000 Graham Williams>
+//
+/// Copyright (C) 2024, Togaware Pty Ltd
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Yixiang Yin
+
+library;
+
+// Group imports by dart, flutter, packages, local. Then alphabetically.
+
 import 'package:flutter/widgets.dart';
 
 Widget addBuildButton(Widget content, Widget buildButton) {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- restructure wordcloud tab to config and panel structure

- Link to associated issue: #117 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: There are a dozen of pre-existing ones.
- [ ] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
