### PR TITLE
Yyx/162 pages widget

### DIFF
--- a/lib/panels/tree/config.dart
+++ b/lib/panels/tree/config.dart
@@ -65,7 +65,6 @@ class TreeConfigState extends ConsumerState<TreeConfig> {
                 debugPrint('TREE CONFIG BUTTON');
                 rSource(context, ref, 'model_template');
                 rSource(context, ref, 'model_build_rpart');
-                treeDisplayKey.currentState?.goToResultPage();
               },
               child: const Text('Build Decision Tree'),
             ),

--- a/lib/panels/tree/config.dart
+++ b/lib/panels/tree/config.dart
@@ -66,7 +66,8 @@ class TreeConfigState extends ConsumerState<TreeConfig> {
                 rSource(context, ref, 'model_template');
                 rSource(context, ref, 'model_build_rpart');
                 // TODO yyx 20240627 How should I restore this effect in the new Widget Pages?
-                // treeDisplayKey.currentState?.goToResultPage();
+                // it failed to work only when user first click build on the panel because the pages are not yet updated.
+                treePagesKey.currentState?.goToResultPage();
               },
               child: const Text('Build Decision Tree'),
             ),

--- a/lib/panels/tree/config.dart
+++ b/lib/panels/tree/config.dart
@@ -65,6 +65,8 @@ class TreeConfigState extends ConsumerState<TreeConfig> {
                 debugPrint('TREE CONFIG BUTTON');
                 rSource(context, ref, 'model_template');
                 rSource(context, ref, 'model_build_rpart');
+                // TODO yyx 20240627 How should I restore this effect in the new Widget Pages?
+                // treeDisplayKey.currentState?.goToResultPage();
               },
               child: const Text('Build Decision Tree'),
             ),

--- a/lib/panels/tree/config.dart
+++ b/lib/panels/tree/config.dart
@@ -67,7 +67,7 @@ class TreeConfigState extends ConsumerState<TreeConfig> {
                 rSource(context, ref, 'model_build_rpart');
                 // TODO yyx 20240627 How should I restore this effect in the new Widget Pages?
                 // it failed to work only when user first click build on the panel because the pages are not yet updated.
-                treePagesKey.currentState?.goToResultPage();
+                // treePagesKey.currentState?.goToResultPage();
               },
               child: const Text('Build Decision Tree'),
             ),

--- a/lib/panels/tree/config.dart
+++ b/lib/panels/tree/config.dart
@@ -27,7 +27,6 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:rattle/panels/tree/panel.dart';
 
 import 'package:rattle/r/source.dart';
 import 'package:rattle/widgets/activity_button.dart';

--- a/lib/panels/tree/display.dart
+++ b/lib/panels/tree/display.dart
@@ -35,6 +35,8 @@ import 'package:rattle/providers/stdout.dart';
 import 'package:rattle/r/extract_tree.dart';
 import 'package:rattle/widgets/show_markdown_file.dart';
 
+import '../../widgets/pages.dart';
+
 /// The tree panel displays the tree instructions or the tree biuld output.
 
 class TreeDisplay extends ConsumerStatefulWidget {
@@ -45,106 +47,37 @@ class TreeDisplay extends ConsumerStatefulWidget {
 }
 
 class TreeDisplayState extends ConsumerState<TreeDisplay> {
-  late PageController _pageController;
-  int _currentPage = 0;
   // number of pages available
-  int numPages = 2;
+  // calculate from the pages number
+  // int numPages = 2;
 
-  void _goToPreviousPage() {
-    if (_currentPage > 0) {
-      _pageController.animateToPage(
-        _currentPage - 1,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-    }
-  }
-
-  void _goToNextPage() {
-    if (_currentPage < numPages - 1) {
-      _pageController.animateToPage(
-        _currentPage + 1,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-    }
-  }
-
-  void goToResultPage() {
-    debugPrint('go to result page');
-    // TODO yyx 20240624 might need change when we have more pages than 2.
-    _goToNextPage();
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _pageController = PageController(initialPage: 0);
-  }
 
   @override
   Widget build(BuildContext context) {
     String stdout = ref.watch(stdoutProvider);
     String content = rExtractTree(stdout);
 
-    return Row(
-      children: [
-        IconButton(
-          icon: Icon(
-            Icons.arrow_left,
-            color: _currentPage > 0 ? Colors.black : Colors.grey,
-            size: 32,
-          ),
-          onPressed: _currentPage > 0 ? _goToPreviousPage : null,
-        ),
-        Expanded(
-          child:
-              // To avoid this error, provide a height limit at a higher (parent) level using the expanded() widget.
-              // Horizontal viewport was given unbounded height.
-              // Viewports expand in the cross axis to fill their container and constrain their children to match
-              // their extent in the cross axis. In this case, a horizontal viewport was given an unlimited amount of
-              // vertical space in which to expand.
-
-              // The relevant error-causing widget was:
-              //   PageView PageView:file:///Users/yinyixiang/repo/my_rattleng/lib/panels/tree/display.dart:112:20
-              PageView(
-            controller: _pageController,
-            onPageChanged: (index) {
-              setState(() {
-                _currentPage = index;
-              });
-            },
+    return Pages(
             children: [
-              showMarkdownFile(treeIntroFile, context),
-              Container(
-                decoration: sunkenBoxDecoration,
-                width: double.infinity,
-                padding: const EdgeInsets.only(left: 10),
-                child: content.isEmpty
-                    ? const Center(
-                        child: Text(
-                          'Click the build button to see the result',
-                        ),
-                      )
-                    : SingleChildScrollView(
-                        child: SelectableText(
-                          content,
-                          style: monoTextStyle,
-                        ),
-                      ),
+    showMarkdownFile(treeIntroFile, context),
+    Container(
+      decoration: sunkenBoxDecoration,
+      width: double.infinity,
+      padding: const EdgeInsets.only(left: 10),
+      child: content.isEmpty
+          ? const Center(
+              child: Text(
+                'Click the build button to see the result',
               ),
+            )
+          : SingleChildScrollView(
+              child: SelectableText(
+                content,
+                style: monoTextStyle,
+              ),
+            ),
+    ),
             ],
-          ),
-        ),
-        IconButton(
-          icon: Icon(
-            Icons.arrow_right,
-            size: 32,
-            color: _currentPage < numPages - 1 ? Colors.black : Colors.grey,
-          ),
-          onPressed: _currentPage < numPages - 1 ? _goToNextPage : null,
-        ),
-      ],
-    );
+          );
   }
 }

--- a/lib/panels/tree/display.dart
+++ b/lib/panels/tree/display.dart
@@ -51,33 +51,32 @@ class TreeDisplayState extends ConsumerState<TreeDisplay> {
   // calculate from the pages number
   // int numPages = 2;
 
-
   @override
   Widget build(BuildContext context) {
     String stdout = ref.watch(stdoutProvider);
     String content = rExtractTree(stdout);
 
     return Pages(
-            children: [
-    showMarkdownFile(treeIntroFile, context),
-    Container(
-      decoration: sunkenBoxDecoration,
-      width: double.infinity,
-      padding: const EdgeInsets.only(left: 10),
-      child: content.isEmpty
-          ? const Center(
-              child: Text(
-                'Click the build button to see the result',
-              ),
-            )
-          : SingleChildScrollView(
-              child: SelectableText(
-                content,
-                style: monoTextStyle,
-              ),
-            ),
-    ),
-            ],
-          );
+      children: [
+        showMarkdownFile(treeIntroFile, context),
+        Container(
+          decoration: sunkenBoxDecoration,
+          width: double.infinity,
+          padding: const EdgeInsets.only(left: 10),
+          child: content.isEmpty
+              ? const Center(
+                  child: Text(
+                    'Click the build button to see the result',
+                  ),
+                )
+              : SingleChildScrollView(
+                  child: SelectableText(
+                    content,
+                    style: monoTextStyle,
+                  ),
+                ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/panels/tree/display.dart
+++ b/lib/panels/tree/display.dart
@@ -47,10 +47,6 @@ class TreeDisplay extends ConsumerStatefulWidget {
 }
 
 class TreeDisplayState extends ConsumerState<TreeDisplay> {
-  // number of pages available
-  // calculate from the pages number
-  // int numPages = 2;
-
   @override
   Widget build(BuildContext context) {
     String stdout = ref.watch(stdoutProvider);

--- a/lib/panels/tree/display.dart
+++ b/lib/panels/tree/display.dart
@@ -36,7 +36,6 @@ import 'package:rattle/r/extract_tree.dart';
 import 'package:rattle/widgets/show_markdown_file.dart';
 
 import '../../widgets/pages.dart';
-import 'panel.dart';
 
 /// The tree panel displays the tree instructions or the tree biuld output.
 
@@ -74,6 +73,7 @@ class TreeDisplayState extends ConsumerState<TreeDisplay> {
         ),
       );
     }
+
     return Pages(
       // key: treePagesKey, // to go to the result page after clicking build button
       children: pages,

--- a/lib/panels/tree/display.dart
+++ b/lib/panels/tree/display.dart
@@ -36,6 +36,7 @@ import 'package:rattle/r/extract_tree.dart';
 import 'package:rattle/widgets/show_markdown_file.dart';
 
 import '../../widgets/pages.dart';
+import 'panel.dart';
 
 /// The tree panel displays the tree instructions or the tree biuld output.
 
@@ -51,10 +52,9 @@ class TreeDisplayState extends ConsumerState<TreeDisplay> {
   Widget build(BuildContext context) {
     String stdout = ref.watch(stdoutProvider);
     String content = rExtractTree(stdout);
-
-    return Pages(
-      children: [
-        showMarkdownFile(treeIntroFile, context),
+    List<Widget> pages = [showMarkdownFile(treeIntroFile, context)];
+    if (content.isNotEmpty) {
+      pages.add(
         Container(
           decoration: sunkenBoxDecoration,
           width: double.infinity,
@@ -72,7 +72,11 @@ class TreeDisplayState extends ConsumerState<TreeDisplay> {
                   ),
                 ),
         ),
-      ],
+      );
+    }
+    return Pages(
+      key: treePagesKey, // to go to the result page after clicking build button
+      children: pages,
     );
   }
 }

--- a/lib/panels/tree/display.dart
+++ b/lib/panels/tree/display.dart
@@ -75,7 +75,7 @@ class TreeDisplayState extends ConsumerState<TreeDisplay> {
       );
     }
     return Pages(
-      key: treePagesKey, // to go to the result page after clicking build button
+      // key: treePagesKey, // to go to the result page after clicking build button
       children: pages,
     );
   }

--- a/lib/panels/tree/panel.dart
+++ b/lib/panels/tree/panel.dart
@@ -31,7 +31,6 @@ import 'package:flutter/material.dart';
 
 import 'package:rattle/panels/tree/config.dart';
 import 'package:rattle/panels/tree/display.dart';
-import 'package:rattle/widgets/pages.dart';
 
 /// The TREE tab supports building decision tree models.
 // final GlobalKey<PagesState> treePagesKey = GlobalKey<PagesState>();

--- a/lib/panels/tree/panel.dart
+++ b/lib/panels/tree/panel.dart
@@ -31,10 +31,10 @@ import 'package:flutter/material.dart';
 
 import 'package:rattle/panels/tree/config.dart';
 import 'package:rattle/panels/tree/display.dart';
+import 'package:rattle/widgets/pages.dart';
 
 /// The TREE tab supports building decision tree models.
-final GlobalKey<TreeDisplayState> treeDisplayKey =
-    GlobalKey<TreeDisplayState>();
+final GlobalKey<PagesState> treePagesKey = GlobalKey<PagesState>();
 
 class TreePanel extends StatelessWidget {
   const TreePanel({super.key});
@@ -44,26 +44,24 @@ class TreePanel extends StatelessWidget {
     // A per the RattleNG pattern, a Tab consists of a Config bar and the
     // results Display().
 
-    return Scaffold(
+    return const Scaffold(
       body: Column(
         children: [
-          const TreeConfig(),
+          TreeConfig(),
 
           // Add a little space blow the config widgets so that things like any
           // underline is not lost not buttons,looking chopped off. We include
           // this here rather than within config to avoid an extra Column
           // widget().  Logically we add the spacer here as part of the tab.
 
-          const SizedBox(height: 10),
+          SizedBox(height: 10),
 
           // We add the Display() which may be a text view that takes up the
           // remaining space to introduce this particular tab's functionality
           // which is then replaced with the output of the build.
 
           Expanded(
-            child: TreeDisplay(
-              key: treeDisplayKey,
-            ),
+            child: TreeDisplay(),
           ),
         ],
       ),

--- a/lib/panels/tree/panel.dart
+++ b/lib/panels/tree/panel.dart
@@ -34,7 +34,7 @@ import 'package:rattle/panels/tree/display.dart';
 import 'package:rattle/widgets/pages.dart';
 
 /// The TREE tab supports building decision tree models.
-final GlobalKey<PagesState> treePagesKey = GlobalKey<PagesState>();
+// final GlobalKey<PagesState> treePagesKey = GlobalKey<PagesState>();
 
 class TreePanel extends StatelessWidget {
   const TreePanel({super.key});

--- a/lib/panels/wordcloud/config.dart
+++ b/lib/panels/wordcloud/config.dart
@@ -34,7 +34,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:rattle/constants/wordcloud.dart';
-import 'package:rattle/panels/wordcloud/panel.dart';
 import 'package:rattle/providers/wordcloud/checkbox.dart';
 // TODO 20240605 gjw WE WILL HAVE OTHER PROVIDERS AS THE APP GROWS. maxword
 // MIGHT BE USED IN OTHER PANELS TOO. PERHAPS WE NEED TO IDENTIFY THESE AS

--- a/lib/panels/wordcloud/config.dart
+++ b/lib/panels/wordcloud/config.dart
@@ -129,7 +129,7 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
                 debugPrint('build clicked on ${timestamp()}');
                 ref.read(wordCloudBuildProvider.notifier).state = timestamp();
 
-                wordCloudDisplayKey.currentState?.goToResultPage();
+                // wordCloudDisplayKey.currentState?.goToResultPage();
               },
               child: const Text('Display Word Cloud'),
             ),

--- a/lib/panels/wordcloud/display.dart
+++ b/lib/panels/wordcloud/display.dart
@@ -36,6 +36,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rattle/constants/sunken_box_decoration.dart';
 import 'package:rattle/constants/wordcloud.dart';
 import 'package:rattle/providers/wordcloud/build.dart';
+import 'package:rattle/widgets/pages.dart';
 import 'package:rattle/widgets/show_markdown_file.dart';
 
 class WordCloudDisplay extends ConsumerStatefulWidget {
@@ -48,7 +49,6 @@ bool buildButtonPressed(String buildTime) {
   return buildTime.isNotEmpty;
 }
 
-// TODO yyx 20240626 make 2 panes, the first one display the intro file and the second one is the wordcloud png
 class WordCloudDisplayState extends ConsumerState<WordCloudDisplay> {
   late PageController _pageController;
   int _currentPage = 0;
@@ -91,7 +91,9 @@ class WordCloudDisplayState extends ConsumerState<WordCloudDisplay> {
     // Build the word cloud widget to be displayed in the tab, consisting of the
     // top configuration and the main panel showing the generated image. Before
     // the build we display a introdcurory text to the functionality.
-    Widget? imageDisplay;
+    List<Widget> pages = [
+      showMarkdownFile(wordCloudMsgFile, context),
+    ];
 
     // Reload the wordcloud image.
 
@@ -143,56 +145,19 @@ class WordCloudDisplayState extends ConsumerState<WordCloudDisplay> {
       // image horizontally, and so ensuring the scrollbar is all the way to the
       // right.
 
-      imageDisplay = Row(
+      Widget imageDisplay = Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           image,
         ],
       );
+      pages.add(
+        SingleChildScrollView(
+          child: imageDisplay,
+        ),
+      );
     }
 
-    return Row(
-      children: [
-        IconButton(
-          icon: Icon(
-            Icons.arrow_left,
-            color: _currentPage > 0 ? Colors.black : Colors.grey,
-            size: 32,
-          ),
-          onPressed: _currentPage > 0 ? _goToPreviousPage : null,
-        ),
-        Expanded(
-          child: PageView(
-            controller: _pageController,
-            onPageChanged: (index) {
-              setState(() {
-                _currentPage = index;
-              });
-            },
-            children: [
-              showMarkdownFile(wordCloudMsgFile, context),
-              Container(
-                decoration: sunkenBoxDecoration,
-                child: buildButtonPressed(lastBuildTime)
-                    ? SingleChildScrollView(
-                        child: imageDisplay,
-                      )
-                    : const Center(
-                        child: Text('Click the build button to see the result'),
-                      ),
-              ),
-            ],
-          ),
-        ),
-        IconButton(
-          icon: Icon(
-            Icons.arrow_right,
-            size: 32,
-            color: _currentPage < numPages - 1 ? Colors.black : Colors.grey,
-          ),
-          onPressed: _currentPage < numPages - 1 ? _goToNextPage : null,
-        ),
-      ],
-    );
+    return Pages(children: pages);
   }
 }

--- a/lib/panels/wordcloud/display.dart
+++ b/lib/panels/wordcloud/display.dart
@@ -33,7 +33,6 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:rattle/constants/sunken_box_decoration.dart';
 import 'package:rattle/constants/wordcloud.dart';
 import 'package:rattle/providers/wordcloud/build.dart';
 import 'package:rattle/widgets/pages.dart';
@@ -50,42 +49,6 @@ bool buildButtonPressed(String buildTime) {
 }
 
 class WordCloudDisplayState extends ConsumerState<WordCloudDisplay> {
-  late PageController _pageController;
-  int _currentPage = 0;
-  // number of pages available
-  int numPages = 2;
-  void _goToPreviousPage() {
-    if (_currentPage > 0) {
-      _pageController.animateToPage(
-        _currentPage - 1,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-    }
-  }
-
-  void _goToNextPage() {
-    if (_currentPage < numPages - 1) {
-      _pageController.animateToPage(
-        _currentPage + 1,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-    }
-  }
-
-  void goToResultPage() {
-    debugPrint('go to result page');
-    // TODO yyx 20240624 might need change when we have more pages than 2.
-    _goToNextPage();
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _pageController = PageController(initialPage: 0);
-  }
-
   @override
   Widget build(BuildContext context) {
     // Build the word cloud widget to be displayed in the tab, consisting of the

--- a/lib/panels/wordcloud/panel.dart
+++ b/lib/panels/wordcloud/panel.dart
@@ -32,9 +32,6 @@ import 'package:flutter/material.dart';
 import 'package:rattle/panels/wordcloud/config.dart';
 import 'package:rattle/panels/wordcloud/display.dart';
 
-final GlobalKey<WordCloudDisplayState> wordCloudDisplayKey =
-    GlobalKey<WordCloudDisplayState>();
-
 class WordCloudPanel extends StatelessWidget {
   const WordCloudPanel({super.key});
   @override
@@ -42,7 +39,7 @@ class WordCloudPanel extends StatelessWidget {
     // A per the RattleNG pattern, a Tab consists of a Config bar and the
     // results Display().
 
-    return Scaffold(
+    return const Scaffold(
       body: Column(
         children: [
           // TODO 20240605 gjw NOT QUIT THE RIGHT SOLUTION YET. IF I SET MAX
@@ -50,14 +47,14 @@ class WordCloudPanel extends StatelessWidget {
           // PARAMETER BUT AFTER THE BUILD/REFRESH THE 10 IS LOST FROM THE
           // CONFIG BAR SINCE IT IS REBUILT. HOW TO FIX THAT AND RETAIN THE
           // MESSAGE WITHTHE CONFIG BAR.
-          const WordCloudConfig(),
+          WordCloudConfig(),
 
           // Add a little space below the underlined input widget so the
           // underline is not lost. Thouoght to include this in config but then
           // I would need an extra Column widget(). Seems okay logically to add
           // the spacer here as part of the tab.
 
-          const SizedBox(height: 10),
+          SizedBox(height: 10),
           // TODO 20240605 gjw THIS FUNCTIONALITY TO MIGRATE TO THE APP SAVE
           // BUTTON TOP RIGHT. KEEP HERE AS A COMMENT UNTIL IMPLEMENTED.
           //
@@ -70,9 +67,7 @@ class WordCloudPanel extends StatelessWidget {
           // overwritten once a dataset is loaded.
 
           Expanded(
-            child: WordCloudDisplay(
-              key: wordCloudDisplayKey,
-            ),
+            child: WordCloudDisplay(),
           ),
         ],
       ),

--- a/lib/widgets/pages.dart
+++ b/lib/widgets/pages.dart
@@ -1,0 +1,86 @@
+// pages.dart
+import 'package:flutter/material.dart';
+
+class Pages extends StatefulWidget {
+  final List<Widget> children;
+
+  const Pages({super.key, required this.children,});
+
+  @override
+  PagesState createState() => PagesState();
+}
+
+class PagesState extends State<Pages> {
+  late PageController _pageController;
+  int _currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(initialPage: 0);
+  }
+
+  void _goToPreviousPage() {
+    if (_currentPage > 0) {
+      _pageController.animateToPage(
+        _currentPage - 1,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  void _goToNextPage() {
+    if (_currentPage < widget.children.length - 1) {
+      _pageController.animateToPage(
+        _currentPage + 1,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  void goToResultPage() {
+    debugPrint('go to result page');
+    // TODO yyx 20240624 might need change when we have more pages than 2.
+    _goToNextPage();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        IconButton(
+          icon: Icon(
+            Icons.arrow_left,
+            color: _currentPage > 0 ? Colors.black : Colors.grey,
+            size: 32,
+          ),
+          onPressed: _currentPage > 0 ? _goToPreviousPage : null,
+        ),
+        Expanded(
+          child: PageView(
+            controller: _pageController,
+            onPageChanged: (index) {
+              setState(() {
+                _currentPage = index;
+              });
+            },
+            children: widget.children,
+          ),
+        ),
+        IconButton(
+          icon: Icon(
+            Icons.arrow_right,
+            size: 32,
+            color: _currentPage < widget.children.length - 1
+                ? Colors.black
+                : Colors.grey,
+          ),
+          onPressed:
+              _currentPage < widget.children.length - 1 ? _goToNextPage : null,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/pages.dart
+++ b/lib/widgets/pages.dart
@@ -22,7 +22,8 @@ class PagesState extends State<Pages> {
     super.initState();
     // By default, show the result page after build.
     // TODO yyx 20240627 not run after the second build.
-    _pageController = PageController(initialPage: widget.children.length - 1);
+    // _pageController = PageController(initialPage: widget.children.length - 1);
+    _pageController = PageController(initialPage: 0);
     // debugPrint('in pageController');
   }
 

--- a/lib/widgets/pages.dart
+++ b/lib/widgets/pages.dart
@@ -4,7 +4,10 @@ import 'package:flutter/material.dart';
 class Pages extends StatefulWidget {
   final List<Widget> children;
 
-  const Pages({super.key, required this.children,});
+  const Pages({
+    super.key,
+    required this.children,
+  });
 
   @override
   PagesState createState() => PagesState();
@@ -17,7 +20,10 @@ class PagesState extends State<Pages> {
   @override
   void initState() {
     super.initState();
-    _pageController = PageController(initialPage: 0);
+    // By default, show the result page after build.
+    // TODO yyx 20240627 not run after the second build.
+    _pageController = PageController(initialPage: widget.children.length - 1);
+    // debugPrint('in pageController');
   }
 
   void _goToPreviousPage() {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- add pages widget and refactor wordcloud and tree display with this widget.

- Link to associated issue: #162 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
