### PR TITLE
yyx/150 wordcloud path renaming

### DIFF
--- a/assets/r/model_build_word_cloud.R
+++ b/assets/r/model_build_word_cloud.R
@@ -73,7 +73,7 @@ set.seed(123)
 # TODO 20240618 gjw REPALCE `WORDCLOUDPATH` WITH `TEMPDIR` FOR ALL
 # TEMPARARY FILES.
 
-png("WORDCLOUDPATH/tmp.png", width=800, height=600, units="px")
+png("TEMPDIR/tmp_wordcloud.png", width=800, height=600, units="px")
 
 # Generate word cloud.
 
@@ -89,9 +89,9 @@ dev.off()
 
 # Trim the white space using magick.
 
-image <- image_read("WORDCLOUDPATH/tmp.png")
+image <- image_read("TEMPDIR/tmp_wordcloud.png")
 trimmed_image <- image_trim(image)
-image_write(trimmed_image, path = "WORDCLOUDPATH/wordcloud.png")
+image_write(trimmed_image, path = "TEMPDIR/wordcloud.png")
 
 # Show the top words
 

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -105,7 +105,7 @@ void rSource(BuildContext context, WidgetRef ref, String script) async {
   // WORD CLOUD
   ////////////////////////////////////////////////////////////////////////
 
-  code = code.replaceAll('WORDCLOUDPATH', tmpDirPath);
+  code = code.replaceAll('TEMPDIR', tmpDirPath);
   code = code.replaceAll('RANDOMORDER', checkbox.toString().toUpperCase());
   code = code.replaceAll('STEM', stem ? 'TRUE' : 'FALSE');
   code = code.replaceAll('PUNCTUATION', punctuation ? 'TRUE' : 'FALSE');


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- rename wordcloud path

- Link to associated issue: #150 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
