### PR TITLE
Yyx/149 stopword lang

### DIFF
--- a/assets/r/model_build_word_cloud.R
+++ b/assets/r/model_build_word_cloud.R
@@ -49,7 +49,7 @@ if (PUNCTUATION) {
 # CHOSEN THROUGH THE GUI.
 
 if (STOPWORD) {
-  docs <- tm_map(docs, removeWords, stopwords("english"))
+  docs <- tm_map(docs, removeWords, stopwords("LANGUAGE"))
 }
 
 # Convert text data to a single character string

--- a/lib/constants/wordcloud.dart
+++ b/lib/constants/wordcloud.dart
@@ -38,5 +38,5 @@ String tmpDirPath = systemTempDir.path;
 String wordCloudImagePath = '$tmpDirPath/wordcloud.png';
 String tmpImagePath = '$tmpDirPath/tmp.png';
 
-const List<String> stopwordLanguage = <String>['english', 'catalan', 'romanian',  'SMART (english extended)', 'danish', 'dutch', 'finnish',
+const List<String> stopwordLanguages = <String>['english', 'catalan', 'romanian',  'SMART (english extended)', 'danish', 'dutch', 'finnish',
 'french', 'german', 'hungarian', 'italian', 'norwegian', 'portuguese', 'russian', 'spanish', 'swedish',];

--- a/lib/constants/wordcloud.dart
+++ b/lib/constants/wordcloud.dart
@@ -38,5 +38,21 @@ String tmpDirPath = systemTempDir.path;
 String wordCloudImagePath = '$tmpDirPath/wordcloud.png';
 String tmpImagePath = '$tmpDirPath/tmp.png';
 
-const List<String> stopwordLanguages = <String>['english', 'catalan', 'romanian',  'SMART (english extended)', 'danish', 'dutch', 'finnish',
-'french', 'german', 'hungarian', 'italian', 'norwegian', 'portuguese', 'russian', 'spanish', 'swedish',];
+const List<String> stopwordLanguages = <String>[
+  'english',
+  'catalan',
+  'romanian',
+  'SMART (english extended)',
+  'danish',
+  'dutch',
+  'finnish',
+  'french',
+  'german',
+  'hungarian',
+  'italian',
+  'norwegian',
+  'portuguese',
+  'russian',
+  'spanish',
+  'swedish',
+];

--- a/lib/constants/wordcloud.dart
+++ b/lib/constants/wordcloud.dart
@@ -37,3 +37,6 @@ var systemTempDir = Directory.systemTemp;
 String tmpDirPath = systemTempDir.path;
 String wordCloudImagePath = '$tmpDirPath/wordcloud.png';
 String tmpImagePath = '$tmpDirPath/tmp.png';
+
+const List<String> stopwordLanguage = <String>['english', 'catalan', 'romanian',  'SMART (english extended)', 'danish', 'dutch', 'finnish',
+'french', 'german', 'hungarian', 'italian', 'norwegian', 'portuguese', 'russian', 'spanish', 'swedish',];

--- a/lib/features/wordcloud/config.dart
+++ b/lib/features/wordcloud/config.dart
@@ -224,7 +224,6 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
                 onSelected: (String? value) {
                   ref.read(languageProvider.notifier).state = value!;
                 },
-                
               ),
             ),
           ],

--- a/lib/features/wordcloud/config.dart
+++ b/lib/features/wordcloud/config.dart
@@ -40,6 +40,7 @@ import 'package:rattle/providers/wordcloud/checkbox.dart';
 // WORDCLOUD PROVIDERS, PERHAPS WITHIN A wordcloudProvider STRUCTURE? FOR
 // CONSIDERATION.
 import 'package:rattle/providers/wordcloud/build.dart';
+import 'package:rattle/providers/wordcloud/language.dart';
 import 'package:rattle/providers/wordcloud/maxword.dart';
 import 'package:rattle/providers/wordcloud/minfreq.dart';
 import 'package:rattle/providers/wordcloud/punctuation.dart';
@@ -60,6 +61,7 @@ class WordCloudConfig extends ConsumerStatefulWidget {
 class _ConfigState extends ConsumerState<WordCloudConfig> {
   final maxWordTextController = TextEditingController();
   final minFreqTextController = TextEditingController();
+  String dropdownValue = stopwordLanguages.first;
   @override
   void initState() {
     super.initState();
@@ -214,10 +216,13 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
             ),
             const SizedBox(width: 20),
             DropdownMenu<String>(
-              initialSelection: stopwordLanguage.first,
-              dropdownMenuEntries: stopwordLanguage.map((s) {
+              initialSelection: stopwordLanguages.first,
+              dropdownMenuEntries: stopwordLanguages.map((s) {
                 return DropdownMenuEntry(value: s, label: s);
               }).toList(),
+              onSelected: (String? value) {
+                ref.read(languageProvider.notifier).state = value!;
+              },
             ),
           ],
         ),

--- a/lib/features/wordcloud/config.dart
+++ b/lib/features/wordcloud/config.dart
@@ -181,6 +181,22 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
                 ),
               ],
             ),
+
+            const SizedBox(width: 20),
+            Row(
+              children: [
+                Checkbox(
+                  value: ref.watch(punctuationProvider),
+                  onChanged: (bool? v) => {
+                    ref.read(punctuationProvider.notifier).state = v!,
+                  },
+                ),
+                const DelayedTooltip(
+                  message: 'Remove punctuation marks such as periods.',
+                  child: Text('Remove Punctuation'),
+                ),
+              ],
+            ),
             const SizedBox(width: 20),
             Row(
               children: [
@@ -197,19 +213,11 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
               ],
             ),
             const SizedBox(width: 20),
-            Row(
-              children: [
-                Checkbox(
-                  value: ref.watch(punctuationProvider),
-                  onChanged: (bool? v) => {
-                    ref.read(punctuationProvider.notifier).state = v!,
-                  },
-                ),
-                const DelayedTooltip(
-                  message: 'Remove punctuation marks such as periods.',
-                  child: Text('Remove Punctuation'),
-                ),
-              ],
+            DropdownMenu<String>(
+              initialSelection: stopwordLanguage.first,
+              dropdownMenuEntries: stopwordLanguage.map((s) {
+                return DropdownMenuEntry(value: s, label: s);
+              }).toList(),
             ),
           ],
         ),

--- a/lib/features/wordcloud/config.dart
+++ b/lib/features/wordcloud/config.dart
@@ -215,14 +215,17 @@ class _ConfigState extends ConsumerState<WordCloudConfig> {
               ],
             ),
             const SizedBox(width: 20),
-            DropdownMenu<String>(
-              initialSelection: stopwordLanguages.first,
-              dropdownMenuEntries: stopwordLanguages.map((s) {
-                return DropdownMenuEntry(value: s, label: s);
-              }).toList(),
-              onSelected: (String? value) {
-                ref.read(languageProvider.notifier).state = value!;
-              },
+            Expanded(
+              child: DropdownMenu<String>(
+                initialSelection: stopwordLanguages.first,
+                dropdownMenuEntries: stopwordLanguages.map((s) {
+                  return DropdownMenuEntry(value: s, label: s);
+                }).toList(),
+                onSelected: (String? value) {
+                  ref.read(languageProvider.notifier).state = value!;
+                },
+                
+              ),
             ),
           ],
         ),

--- a/lib/providers/wordcloud/language.dart
+++ b/lib/providers/wordcloud/language.dart
@@ -1,0 +1,31 @@
+/// A provider to remember the language used in the wordcloud
+//
+// Time-stamp: <Thursday 2024-06-06 05:58:50 +1000 Graham Williams>
+//
+/// Copyright (C) 2024, Togaware Pty Ltd
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Yixiang Yin
+
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rattle/constants/wordcloud.dart';
+
+final languageProvider = StateProvider<String>((ref) => stopwordLanguages.first);

--- a/lib/providers/wordcloud/language.dart
+++ b/lib/providers/wordcloud/language.dart
@@ -28,4 +28,5 @@ library;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:rattle/constants/wordcloud.dart';
 
-final languageProvider = StateProvider<String>((ref) => stopwordLanguages.first);
+final languageProvider =
+    StateProvider<String>((ref) => stopwordLanguages.first);

--- a/lib/r/source.dart
+++ b/lib/r/source.dart
@@ -39,6 +39,7 @@ import 'package:rattle/providers/path.dart';
 import 'package:rattle/providers/pty.dart';
 import 'package:rattle/providers/target.dart';
 import 'package:rattle/providers/wordcloud/checkbox.dart';
+import 'package:rattle/providers/wordcloud/language.dart';
 import 'package:rattle/providers/wordcloud/maxword.dart';
 import 'package:rattle/providers/wordcloud/minfreq.dart';
 import 'package:rattle/providers/wordcloud/punctuation.dart';
@@ -73,6 +74,7 @@ void rSource(BuildContext context, WidgetRef ref, String script) async {
   bool partition = ref.read(partitionProvider);
   String maxWord = ref.read(maxWordProvider);
   String minFreq = ref.read(minFreqProvider);
+  String language = ref.read(languageProvider);
 
   // First obtain the text from the script.
 
@@ -110,6 +112,7 @@ void rSource(BuildContext context, WidgetRef ref, String script) async {
   code = code.replaceAll('STEM', stem ? 'TRUE' : 'FALSE');
   code = code.replaceAll('PUNCTUATION', punctuation ? 'TRUE' : 'FALSE');
   code = code.replaceAll('STOPWORD', stopword ? 'TRUE' : 'FALSE');
+  code = code.replaceAll('LANGUAGE', language);
 
   (minFreq.isNotEmpty && num.tryParse(minFreq) != null)
       ? code = code.replaceAll('MINFREQ', num.parse(minFreq).toInt().toString())


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- add dropdown menu to let user choose stopword language

- Link to associated issue: #149 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [ ] Changes adhere to the style and coding guideline
- [ ] No confidential information
- [ ] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
- [x] Added a reviewer

## Finalising

Once PR discussion is complete and reviewer has approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev (gjwgit)
